### PR TITLE
Add option to use vusted installed locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,6 @@ See [vusted.helper](https://github.com/notomo/vusted/blob/master/lua/vusted/help
 - `VUSTED_SLOW`
     - For example if you set 1000, output handler adds summary about the tests that elapsed 1000ms or more.
     - can use only if the output handler is `vusted.default`.
+- `VUSTED_USE_LOCAL`
+    - Set this flag to true or 1 if vusted was installed locally, e.g., with `luarocks install --local vusted`.
+    - default: nil

--- a/bin/vusted_entry.vim
+++ b/bin/vusted_entry.vim
@@ -8,8 +8,12 @@ endif
 try
 lua <<EOF
     local version = _VERSION:sub(5)
-    local deploy_lua_dir = vim.fn.trim(vim.fn.system('luarocks --lua-version=' .. version .. ' config deploy_lua_dir'))
-    local deploy_lib_dir = vim.fn.trim(vim.fn.system('luarocks --lua-version=' .. version .. ' config deploy_lib_dir'))
+    local luarocks_cmd = 'luarocks --lua-version=' .. version
+    if vim.env.VUSTED_USE_LOCAL then
+        luarocks_cmd = luarocks_cmd .. ' --local'
+    end
+    local deploy_lua_dir = vim.fn.trim(vim.fn.system(luarocks_cmd .. ' config deploy_lua_dir'))
+    local deploy_lib_dir = vim.fn.trim(vim.fn.system(luarocks_cmd .. ' config deploy_lib_dir'))
     package.path = package.path .. ';' .. deploy_lua_dir .. '/?.lua;' .. deploy_lua_dir .. '/?/init.lua'
     package.cpath = package.cpath .. ';' .. deploy_lib_dir .. '/?.so;' .. deploy_lib_dir .. '/?/init.so'
     require('vusted/run')()


### PR DESCRIPTION
I prefer to install luarocks packages using the `--local` option but vusted assumes it is installed globally. This adds an option to use local install. If the variable is not set, vusted assumes global as before.